### PR TITLE
Adiciona cobertura de testes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,17 @@ env:
   - DOCKER_COMPOSE_VERSION=1.24.1
 
 install:
+  - echo "RUN npm install coveralls" >> Dockerfile
+  - echo "ENV REPO_TOKEN ${COVERALLS_REPO_TOKEN}" >> Dockerfile
+  - echo "ENV TRAVIS_BRANCH ${TRAVIS_BRANCH}" >> Dockerfile
+  - echo "ENV TRAVIS_JOB_ID ${TRAVIS_JOB_ID}" >> Dockerfile
+  - echo "ENV CI ${CI}" >> Dockerfile
+  - echo "ENV TRAVIS ${TRAVIS}" >> Dockerfile
   - docker-compose up --build -d
 
 script:
-  - docker exec -it foodcare-web ng test --watch=false
+  - docker exec -it foodcare-web ng test --watch=false --code-coverage
 
 after_script:
+  - docker exec -it foodcare-web sh -c "cat ./coverage/foodcare/lcov.info | ./node_modules/coveralls/bin/coveralls.js"
   - docker-compose down --remove-orphans

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
     <a href="https://www.gnu.org/licenses/gpl-3.0" alt="Licença: GPL v3" >
         <img src="https://img.shields.io/badge/License-GPLv3-blue.svg" />
     </a>
+    <a href='https://coveralls.io/github/fga-eps-mds/2019.2-FoodCare-WebApp?branch=master'><img src='https://coveralls.io/repos/github/fga-eps-mds/2019.2-FoodCare-WebApp/badge.svg?branch=master' alt='Coverage Status' /></a>
 </p>
 
 <p align="center">
@@ -69,6 +70,15 @@ Para subir a aplicação no endereço `0.0.0.0` e na porta 4200 utilize o seguin
 
 A aplicação estará disponível em `http://localhost:4200`.
 
+## Ambientes
+
+### Homologação
+
+`https://foodcarehomol.netlify.com/`
+
+### Produção
+
+`https://foodcare.netlify.com/`
 <!-- ## Testes
 
 Descreva e mostre como rodar testes. -->


### PR DESCRIPTION
Adiciona configuração para exibição da cobertura de testes sobre o código.

## Mudanças propostas 
- Adiciona etapa no script para mandar dados para o coveralls
- Adiciona badge para exibir a porcentagem de cobertura de código
- Adapta a configuração do travis para testes
